### PR TITLE
remove excessive "effect" part of each line of the overlay, and correct "smithing" name

### DIFF
--- a/src/main/java/com/MiningSpecialEffectTracker/MiningSpecialEffectTrackerOverlay.java
+++ b/src/main/java/com/MiningSpecialEffectTracker/MiningSpecialEffectTrackerOverlay.java
@@ -72,31 +72,31 @@ class MiningSpecialEffectTrackerOverlay extends OverlayPanel {
 
                 if (config.showSmithingEffect())
                     elems.add(LineComponent.builder()
-                            .left("Smithing Effect:")
+                            .left("Smithing:")
                             .right(String.format("%d", plugin.smithingEffect))
                             .build());
 
                 if (config.showVarrockEffect())
                     elems.add(LineComponent.builder()
-                            .left("Varrock Armour Effect:")
+                            .left("Varrock Armour:")
                             .right(String.format("%d", plugin.varrockArmourEffect))
                             .build());
 
                 if (config.showCelestialEffect())
                     elems.add(LineComponent.builder()
-                            .left("Celestial Ring Effect:")
+                            .left("Celestial Ring:")
                             .right(String.format("%d", plugin.celestrialRingEffect))
                             .build());
 
                 if (config.showCapeEffect())
                     elems.add(LineComponent.builder()
-                            .left("Mining Cape Effect:")
+                            .left("Mining Cape:")
                             .right(String.format("%d", plugin.miningCapeEffect))
                             .build());
 
                 if (config.showGlovesEffect())
                     panelComponent.getChildren().add(LineComponent.builder()
-                            .left("Mining Gloves Effect:")
+                            .left("Mining Gloves:")
                             .right(String.format("%d", plugin.miningGlovesEffect))
                             .build());
             }

--- a/src/main/java/com/MiningSpecialEffectTracker/MiningSpecialEffectTrackerOverlay.java
+++ b/src/main/java/com/MiningSpecialEffectTracker/MiningSpecialEffectTrackerOverlay.java
@@ -72,7 +72,7 @@ class MiningSpecialEffectTrackerOverlay extends OverlayPanel {
 
                 if (config.showSmithingEffect())
                     elems.add(LineComponent.builder()
-                            .left("Smithing:")
+                            .left("Smelting:")
                             .right(String.format("%d", plugin.smithingEffect))
                             .build());
 


### PR DESCRIPTION
Closes #3

The `effect` can be easily implied, and they take up so much space that's otherwise not needed. This fixes #3 as by default, there's not enough space in the overlay to support large numbers; without `effect` being there, there should be enough.

also rename `smithing` to `smelting`, since that's what it is.

